### PR TITLE
Added path cleanup from 30beb9be3ba35768198b8348cfd29d029eab9b0e to the mangadl.link creation

### DIFF
--- a/manga-downloader.py
+++ b/manga-downloader.py
@@ -214,6 +214,7 @@ class Manga(object):
         self.chapter_list = []
 
     def createFolder(self, path):
+        path = cleanPath(path)
         if not os.path.exists(path):
             os.makedirs(path)
         with open(path + '/mangadl.link', 'w') as f:


### PR DESCRIPTION
Missed applying the path cleanup to the creation of the mangadl.link file which resulted in it being stored in a different directory.
